### PR TITLE
Feat: Save logs to accessible location for easier debugging in Android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
     <uses-permission android:name="android.permission.READ_LOGS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.ACCESS_SUPERUSER" />
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     
     <application android:label="@string/app_name"
         android:name=".DynamicColorApplication"

--- a/app/src/main/java/com/tortel/syslog/Result.java
+++ b/app/src/main/java/com/tortel/syslog/Result.java
@@ -27,6 +27,7 @@ public class Result {
 	private boolean success;
 	private Throwable exceptions;
 	private int message;
+	private String stingmessage;
 	private RunCommand command;
 	private String archiveName;
 	
@@ -59,9 +60,13 @@ public class Result {
 	public Throwable getException(){
 		return exceptions;
 	}
-	
+
 	public void setMessage(@StringRes int message){
-		this.message= message; 
+		this.message= message;
+	}
+
+	public void setStringMessage(String message) {
+		this.stingmessage = message;
 	}
 
 	@StringRes

--- a/app/src/main/res/values/exception-details.xml
+++ b/app/src/main/res/values/exception-details.xml
@@ -40,8 +40,8 @@
     <string name="exception_unknown">There was an unknown exception while running. Please submit a bug report, and include the SU implementation you use.</string>
 
     <!-- No send intent available -->
-    <string name="exception_send">There was no application available to send a zip file. The logs have been saved, but please install or enable
-        an email application or cloud storage application to easily send the file.</string>
+    <string name="exception_send">There was no application available to send a zip file. The logs have been saved at Downloads Folder, 
+        but please install or enable an email application or cloud storage application to easily send the file.</string>
         
     <!-- Low space on primary storage -->
     <string name="exception_space">Your primary storage does not have enough free space. You currently have %.1f MB free. SysLog can try to free space by cleaning old log files.</string>


### PR DESCRIPTION
Feat: Update log saving location to improve accessibility on Android 11+

Previously, logs were saved to the /android/data/com.tortel.syslog/ directory, which became inaccessible starting from Android 11 due to scoped storage restrictions. This update changes the log saving mechanism to store logs in the Downloads/SysLog/ directory, ensuring logs are saved in an accessible location for easier retrieval and debugging.

This update is especially useful for developers working with custom Android OS versions or custom kernel upstreaming, where network connectivity (Wi-Fi, SIM, Bluetooth) may be disrupted. With this change, users can now access and share logs using alternative methods, improving troubleshooting even in offline scenarios.
